### PR TITLE
Fix lincence and dependencies

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-com.unity.networking.backgrounddownload copyright © 2019-2020 Unity Technologies ApS
+com.unity.networking.backgrounddownload copyright © 2020 Unity Technologies ApS
 
 Licensed under the Unity Companion License for Unity-dependent projects--see [Unity Companion License](http://www.unity3d.com/legal/licenses/Unity_Companion_License). 
 

--- a/package.json
+++ b/package.json
@@ -5,5 +5,6 @@
 	"unity": "2020.1",
 	"description": "Enable file downloads in background for mobile platforms\nAllows to launch file downloads that will continue even if the app goes into background or gets quit by the operating system. The downloads can be picked the next time the app is started.\nSupported platforms are: \n\u25AA Android \n\u25AA iOS \n\u25AA Universal Windows Platform",
 	"dependencies": {
+		"com.unity.modules.androidjni": "1.0.0"
 	}
 }


### PR DESCRIPTION
For Android support BackgroundDownload uses APIs from built-in module AndroidJNI, it means that module has to be listed as dependency so the user cannot disable the module (results in compilation errors).