### PR TITLE
Fix/android download performance

### DIFF
--- a/Runtime/BackgroundDownload.cs
+++ b/Runtime/BackgroundDownload.cs
@@ -4,13 +4,15 @@ using System.Collections.Generic;
 using UnityEngine;
 
 #if UNITY_EDITOR
-using BackgroundDownloadimpl = Unity.Networking.BackgroundDownloadEditor;
+using BackgroundDownloadimpl = Unity.Networking.BackgroundDownloadDirect;
 #elif UNITY_ANDROID
 using BackgroundDownloadimpl = Unity.Networking.BackgroundDownloadAndroid;
 #elif UNITY_IOS
 using BackgroundDownloadimpl = Unity.Networking.BackgroundDownloadiOS;
 #elif UNITY_WSA_10_0
 using BackgroundDownloadimpl = Unity.Networking.BackgroundDownloadUWP;
+#else
+using BackgroundDownloadimpl = Unity.Networking.BackgroundDownloadDirect;
 #endif
 
 namespace Unity.Networking

--- a/Runtime/BackgroundDownloadAndroid.cs
+++ b/Runtime/BackgroundDownloadAndroid.cs
@@ -153,7 +153,6 @@ namespace Unity.Networking
             return Task.CompletedTask;
         }
         
-      
         static BackgroundDownloadAndroid Recreate(long id)
         {
             try

--- a/Runtime/BackgroundDownloadAndroid.cs
+++ b/Runtime/BackgroundDownloadAndroid.cs
@@ -24,9 +24,8 @@ namespace Unity.Networking
         static AndroidJavaClass _backgroundDownloadClass;
         private CancellationTokenSource _CancellationTokenSource;
         private AndroidJavaObject _download;
-        private long _id = 0;
+        private long _id = int.MinValue;
         private string _tempFilePath;
-        private bool _started;
         
         static AndroidJavaObject _currentActivity;
         static Callback _finishedCallback;
@@ -81,8 +80,6 @@ namespace Unity.Networking
             _download = download;
             _config.url = QueryDownloadUri();
             _config.filePath = QueryDestinationPath(out _tempFilePath);
-            
-            _started = true;
             CheckFinished();
         }
         
@@ -153,7 +150,6 @@ namespace Unity.Networking
                             _download.Call("addRequestHeader", header.Key, val);
 
             _id = _download.Call<long>("start", _currentActivity);
-            _started = true;
             return Task.CompletedTask;
         }
         
@@ -210,7 +206,7 @@ namespace Unity.Networking
 
         void CheckFinished()
         {
-            if (_status == BackgroundDownloadStatus.Downloading)
+            if (_status == BackgroundDownloadStatus.Downloading && _id !=  int.MinValue)
             {
                 CheckFinishedAsync();
             }

--- a/Runtime/BackgroundDownloadAndroid.cs
+++ b/Runtime/BackgroundDownloadAndroid.cs
@@ -10,14 +10,18 @@ using UnityEngine;
 
 namespace Unity.Networking
 {
-
     class BackgroundDownloadAndroid : BackgroundDownload
     {
         private const string TEMP_FILE_SUFFIX = ".part";
         static AndroidJavaClass _playerClass;
         static AndroidJavaClass _backgroundDownloadClass;
         private CancellationTokenSource _CancellationTokenSource;
+        private AndroidJavaObject _download;
+        private long _id = 0;
+        private string _tempFilePath;
+        
         static AndroidJavaObject _currentActivity;
+        static Callback _finishedCallback;
         
         class Callback : AndroidJavaProxy
         {
@@ -34,13 +38,6 @@ namespace Unity.Networking
                 }
             }
         }
-
-        static Callback _finishedCallback;
-
-        AndroidJavaObject _download;
-        long _id = 0;
-        string _tempFilePath;
-        
         
         static void SetupBackendStatics()
         {
@@ -64,51 +61,9 @@ namespace Unity.Networking
         internal BackgroundDownloadAndroid(BackgroundDownloadConfig config)
             : base(config)
         {
-            _CancellationTokenSource = new CancellationTokenSource();
             SetupBackendStatics();
+            _CancellationTokenSource = new CancellationTokenSource();
             StartDownloadAsync(_CancellationTokenSource.Token);
-            
-            
-           /*
-            string filePath = Path.Combine(Application.persistentDataPath, config.filePath);
-            _tempFilePath = filePath + TEMP_FILE_SUFFIX;
-            if (File.Exists(filePath))
-                File.Delete(filePath);
-            if (File.Exists(_tempFilePath))
-                File.Delete(_tempFilePath);
-            else
-            {
-                var dir = Path.GetDirectoryName(filePath);
-                if (!Directory.Exists(dir))
-                    Directory.CreateDirectory(dir);
-            }
-            string fileUri = "file://" + _tempFilePath;
-            bool allowMetered = false;
-            bool allowRoaming = false;
-            switch (_config.policy)
-            {
-                case BackgroundDownloadPolicy.AllowMetered:
-                    allowMetered = true;
-                    break;
-                case BackgroundDownloadPolicy.AlwaysAllow:
-                    allowMetered = true;
-                    allowRoaming = true;
-                    break;
-                default:
-                    break;
-            }
-            _download = _backgroundDownloadClass.CallStatic<AndroidJavaObject>("create", config.url.AbsoluteUri, fileUri);
-
-            _download.Call("setAllowMetered", allowMetered);
-            _download.Call("setAllowRoaming", allowRoaming);
-            if (config.requestHeaders != null)
-                foreach (var header in config.requestHeaders)
-                    if (header.Value != null)
-                        foreach (var val in header.Value)
-                            _download.Call("addRequestHeader", header.Key, val);
-            var activity = _playerClass.GetStatic<AndroidJavaObject>("currentActivity");
-            _id = _download.Call<long>("start", activity);
-            */
         }
 
         private void StartDownloadAsync(CancellationToken cancellationToken)
@@ -118,12 +73,12 @@ namespace Unity.Networking
             Task.Run(async () =>
             {
                 AndroidJNI.AttachCurrentThread();
-                await RunDownload(filePath);
+                await RunDownloadTask(filePath);
                 AndroidJNI.DetachCurrentThread();
             }, cancellationToken);  
         }
         
-        private Task RunDownload(string filePath)
+        private Task RunDownloadTask(string filePath)
         {
             _tempFilePath = filePath + TEMP_FILE_SUFFIX;
             
@@ -169,6 +124,7 @@ namespace Unity.Networking
                             _download.Call("addRequestHeader", header.Key, val);
 
             _id = _download.Call<long>("start", _currentActivity);
+            
             return Task.CompletedTask;
         }
         
@@ -259,7 +215,12 @@ namespace Unity.Networking
 
         void RemoveDownload()
         {
-            _download.Call("remove");
+            Task.Run(() =>
+            {
+                AndroidJNI.AttachCurrentThread();
+                _download.Call("remove");
+                AndroidJNI.DetachCurrentThread();
+            });  
         }
 
         public override bool keepWaiting { get { return _status == BackgroundDownloadStatus.Downloading; } }

--- a/Runtime/BackgroundDownloadAndroid.cs
+++ b/Runtime/BackgroundDownloadAndroid.cs
@@ -242,6 +242,10 @@ namespace Unity.Networking
 
         public override void Dispose()
         {
+            _CancellationTokenSource?.Cancel();
+            _CancellationTokenSource?.Dispose();
+            _CancellationTokenSource = null;
+            
             RemoveDownload();
             base.Dispose();
         }

--- a/Runtime/BackgroundDownloadAndroid.cs
+++ b/Runtime/BackgroundDownloadAndroid.cs
@@ -29,7 +29,7 @@ namespace Unity.Networking
         
         static AndroidJavaObject _currentActivity;
         static Callback _finishedCallback;
-        static AsyncLock _asyncLock = new ();
+        static readonly AsyncLock _asyncLock = new ();
         
         class Callback : AndroidJavaProxy
         {

--- a/Runtime/BackgroundDownloadDirect.cs
+++ b/Runtime/BackgroundDownloadDirect.cs
@@ -1,0 +1,104 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using Cysharp.Threading.Tasks;
+using UnityEngine;
+using UnityEngine.Networking;
+
+namespace Unity.Networking
+{
+    public sealed class BackgroundDownloadDirect : BackgroundDownload
+    {
+        private UnityWebRequest         m_Request;
+        private CancellationTokenSource m_Cts;
+
+        public BackgroundDownloadDirect(BackgroundDownloadConfig config) : base(config)
+        {
+            m_Cts = new CancellationTokenSource();
+            StartDownloadAsync(m_Cts.Token);
+        }
+
+        public override bool keepWaiting => _status == BackgroundDownloadStatus.Downloading;
+
+        protected override float GetProgress()
+        {
+            return m_Request?.downloadProgress ?? 1.0f;
+        }
+
+        private async void StartDownloadAsync(CancellationToken cancellationToken)
+        {
+            try
+            {
+                using (m_Request = UnityWebRequest.Get(config.url))
+                {
+                    config.requestHeaders?.Where(h => h.Value != null)
+                          .ToList()
+                          .ForEach(h => h.Value.ForEach(v => m_Request.SetRequestHeader(h.Key, v)));
+
+                    try
+                    {
+                        await m_Request.SendWebRequest().WithCancellation(cancellationToken);
+                    }
+                    catch (Exception e) when (e is UnityWebRequestException or OperationCanceledException)
+                    {
+                        _status = BackgroundDownloadStatus.Failed;
+                        _error = e.Message;
+                        return;
+                    }
+
+                    if (m_Request.result == UnityWebRequest.Result.Success)
+                    {
+                        string filePath = Path.Combine(Application.persistentDataPath, config.filePath);
+                        string dir = Path.GetDirectoryName(filePath);
+                        if (!Directory.Exists(dir))
+                            Directory.CreateDirectory(dir);
+                        try
+                        {
+                            await File.WriteAllBytesAsync(filePath, m_Request.downloadHandler.data);
+                            _status = BackgroundDownloadStatus.Done;
+                        }
+                        catch (Exception e)
+                        {
+                            _status = BackgroundDownloadStatus.Failed;
+                            _error = e.Message;
+                            return;
+                        }
+                    }
+                    else
+                    {
+                        _status = BackgroundDownloadStatus.Failed;
+                        _error = m_Request.error;
+                        return;
+                    }
+                }
+            }
+            catch (Exception e)
+            {
+                _status = BackgroundDownloadStatus.Failed;
+                _error = e.Message;
+                Debug.unityLogger.LogError(nameof(BackgroundDownloadDirect), $"An unexpected error occured while downloading '{config.url}': {e.Message}");
+                return;
+            }
+        }
+
+        internal static Dictionary<string, BackgroundDownload> LoadDownloads()
+        {
+            return new Dictionary<string, BackgroundDownload>();
+        }
+
+        internal static void SaveDownloads(Dictionary<string, BackgroundDownload> downloads)
+        {
+            // do nothing
+        }
+
+        public override void Dispose()
+        {
+            m_Cts?.Cancel();
+            m_Cts?.Dispose();
+            m_Cts = null;
+            base.Dispose();
+        }
+    }
+}

--- a/Runtime/BackgroundDownloadDirect.cs.meta
+++ b/Runtime/BackgroundDownloadDirect.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f0fe3179cf3660a4e89ec0794bd2a225
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Plugins/Android/backgrounddownload.androidlib/build.gradle
+++ b/Runtime/Plugins/Android/backgrounddownload.androidlib/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 32
-    buildToolsVersion '34.0.0'
+    buildToolsVersion '32.0.0'
 
     defaultConfig {
         minSdkVersion 29

--- a/Runtime/Plugins/Android/backgrounddownload.androidlib/build.gradle
+++ b/Runtime/Plugins/Android/backgrounddownload.androidlib/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 32
-
+    buildToolsVersion '34.0.0'
 
     defaultConfig {
         minSdkVersion 29

--- a/Runtime/Plugins/Android/backgrounddownload.androidlib/build.gradle
+++ b/Runtime/Plugins/Android/backgrounddownload.androidlib/build.gradle
@@ -1,11 +1,11 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 32
 
 
     defaultConfig {
-        minSdkVersion 16
-        targetSdkVersion 28
+        minSdkVersion 29
+        targetSdkVersion 32
     }
 }

--- a/Runtime/Plugins/Android/backgrounddownload.androidlib/src/main/AndroidManifest.xml
+++ b/Runtime/Plugins/Android/backgrounddownload.androidlib/src/main/AndroidManifest.xml
@@ -1,7 +1,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.unity3d.backgrounddownload">
     <application>
-        <receiver android:name="com.unity3d.backgrounddownload.CompletionReceiver">
+        <receiver android:name="com.unity3d.backgrounddownload.CompletionReceiver" android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.DOWNLOAD_COMPLETE" />
             </intent-filter>

--- a/Runtime/Unity.Networking.BackgroundDownload.asmdef
+++ b/Runtime/Unity.Networking.BackgroundDownload.asmdef
@@ -1,11 +1,23 @@
 {
     "name": "Unity.Networking.BackgroundDownload",
-    "references": [],
+    "rootNamespace": "",
+    "references": [
+        "UniTask"
+    ],
     "includePlatforms": [
         "Android",
         "Editor",
         "iOS",
-        "WSA"
+        "WSA",
+        "WindowsStandalone32",
+        "WindowsStandalone64"
     ],
-    "excludePlatforms": []
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
 }


### PR DESCRIPTION

1. Major Jni calls now runs on thread pool
2. Used async lock to prevent concurrency issues